### PR TITLE
修复部分文件下载失败问题

### DIFF
--- a/Downloader/src/main/java/cn/aigestudio/downloader/bizs/DLTask.java
+++ b/Downloader/src/main/java/cn/aigestudio/downloader/bizs/DLTask.java
@@ -198,7 +198,7 @@ class DLTask implements Runnable, IDLThreadListener {
             int start = i * threadLength;
             int end = start + threadLength - 1;
             if (i == threadSize - 1) {
-                end = start + threadLength + remainder;
+                end = start + threadLength + remainder - 1;
             }
             DLThreadInfo threadInfo =
                     new DLThreadInfo(UUID.randomUUID().toString(), info.baseUrl, start, end);


### PR DESCRIPTION
由于最后一部分指定的下载范围超过了文件的大小，导致一些服务器在下载时数据返回错误，导致了下载的文件比真实文件要大，测试下载链接：http://kuaiting-v.oss-cn-beijing.aliyuncs.com/download/tingting_android_v2.1.0_100001.apk?t=14709926465191
